### PR TITLE
Add Level API without DB storage

### DIFF
--- a/LevelEvaluatorAndProvider/.gitignore
+++ b/LevelEvaluatorAndProvider/.gitignore
@@ -1,0 +1,112 @@
+.DS_Store
+.vscode/
+
+# Python related stuff
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# PyCharm
+.idea
+*.iml

--- a/LevelEvaluatorAndProvider/EvaluatorEndpointTesting.py
+++ b/LevelEvaluatorAndProvider/EvaluatorEndpointTesting.py
@@ -1,0 +1,24 @@
+import uuid
+import urllib.request
+import json
+
+
+if __name__ == "__main__":
+    TEST_LEVEL_REQUEST_NO_TELEMETRY = {
+        "requestId":str(uuid.uuid4()),
+            "playerId":"EndpointTest",
+            "telemetry":{}
+    }
+
+    TEST_ENDPOINT = "http://localhost:5000/level"
+
+    req = urllib.request.Request(TEST_ENDPOINT)
+    req.add_header('Content-Type', 'application/json; charset=utf-8')
+    json_data = json.dumps(TEST_LEVEL_REQUEST_NO_TELEMETRY)
+    data_bytes = json_data.encode('utf-8')   # needs to be bytes
+    req.add_header('Content-Length', len(data_bytes))
+
+    with urllib.request.urlopen(req, data_bytes) as f:
+        response_json = json.loads(f.read())
+
+    print(response_json)

--- a/LevelEvaluatorAndProvider/LevelEvaluators/EnjoymentSurfaceContentGenerator.py
+++ b/LevelEvaluatorAndProvider/LevelEvaluators/EnjoymentSurfaceContentGenerator.py
@@ -1,0 +1,8 @@
+
+
+class EnjoymentSurfaceContentGenerator():
+    def __init__():
+        pass
+    
+    def GenerateLevel():
+        pass

--- a/LevelEvaluatorAndProvider/LevelEvaluators/LevelSliceClient.py
+++ b/LevelEvaluatorAndProvider/LevelEvaluators/LevelSliceClient.py
@@ -1,0 +1,12 @@
+import urllib.request
+import json
+
+LEVEL_SLICE_CLIENT_URL = "https://mariovae.herokuapp.com/level?zs={latent_vectors}&experimentName={experiment_name}&modelName={generator_model_name}"
+
+def GetLevelSlicesForVectors(latent_vectors, experiment_name, generator_model_name="mariovae_z_dim_2"):
+    response = urllib.request.urlopen(LEVEL_SLICE_CLIENT_URL.format(latent_vectors=latent_vectors, experiment_name=experiment_name, generator_model_name=generator_model_name).replace(" ","%20"))
+    return  json.loads(response.read())
+
+if __name__ == "__main__":
+    TEST_VECTORS = [[3.14, 3.14]]
+    print( GetLevelSlicesForVectors(latent_vectors=TEST_VECTORS, experiment_name="test-python-client"))

--- a/LevelEvaluatorAndProvider/LevelEvaluators/RandomLevelGenerator.py
+++ b/LevelEvaluatorAndProvider/LevelEvaluators/RandomLevelGenerator.py
@@ -1,0 +1,30 @@
+import random
+from .LevelSliceClient import GetLevelSlicesForVectors
+
+
+class RandomLevelGenerator():
+    def __init__(self):
+        self.name = "Random Level Generator"
+        self.generator_model_to_use = "mariovae_z_dim_2"
+    
+    def GenerateRandomVectors(self, num_vectors, vector_length):
+        latent_vectors = []
+
+        for vector_i in range(num_vectors):
+        
+            new_vector = []
+            for element_i in range(vector_length):
+                new_vector.append(random.uniform(0, 10))
+        
+            latent_vectors.append(new_vector)
+        
+        return latent_vectors
+
+
+    def GenerateLevel(self, request_data):
+        latent_vectors = self.GenerateRandomVectors(5, 2)
+        level_representation = GetLevelSlicesForVectors(latent_vectors=latent_vectors, experiment_name=request_data["experimentName"], generator_model_name=self.generator_model_to_use)
+        return {
+            "latentVectors":latent_vectors,
+            "levelRepresentation":level_representation
+        }

--- a/LevelEvaluatorAndProvider/app.py
+++ b/LevelEvaluatorAndProvider/app.py
@@ -1,0 +1,202 @@
+import os
+import json
+import time
+
+from flask import Flask, jsonify, request
+
+# import psycopg2
+# from db_interface import Query
+
+from LevelEvaluators.RandomLevelGenerator import RandomLevelGenerator as LevelGenerator
+
+
+app = Flask(__name__)
+level_generator = LevelGenerator()
+
+
+# try:
+#     from dotenv import load_dotenv
+
+#     load_dotenv()
+# except ModuleNotFoundError:
+#     print("Couldn't load the local .env file.")
+
+# db_url = os.environ["DATABASE_URL"]
+
+# #Create the table
+# db = psycopg2.connect(db_url)
+# query_db = Query(db)
+# query_db.create_query_table()
+# db.close()
+
+
+DEFAULT_LEVEL_DATA = []
+
+
+REQUEST_FORMAT = """{
+        "requestId":STRING,
+        "playerId":STRING,
+        "telemetry":{ // Empty for a new player
+            "latentVectors": [S x [ N dimenstional vector ]],
+            "levelRepresentation":[
+                S x level slice representations of the form:
+                [ H x W array of INTs represetning block types ],
+                ...
+            ],
+            "markedUplayable": BOOL,
+            "endedEarly": BOOL,
+            "surveyResults":{
+                "enjoyment": INT,
+                "desiredNovelty": INT
+            }
+            ...
+        }
+    }"""
+
+RESPONSE_FORMAT = """
+    {
+        "requestId":STRING,
+        "latentVector":[ N dimenstional vector ],
+        "experimentName":STRING,
+        "levelRepresentation":[
+            S x level slice representations of the form:
+            [ H x W array of INTs represetning block types ],
+            ...
+        ]
+    }
+"""
+
+
+def GetPlayerPreferenceFromPlayerTelemetry(player_request_data):
+    """
+    Simple approach to the 'Player Actions to Player Preferences' model.
+
+    For now, ignores any telemtry data and just converts the survey data to floats between 0 and 1 if the survey was completed.
+    """
+    
+    marked_unplayable = "markedUnplayable" in player_request_data["telemetry"] and player_request_data["telemetry"]["markedUnplayable"]
+    eneded_early = "endedEarly" in player_request_data["telemetry"] and player_request_data["telemetry"]["endedEarly"]
+
+    player_preferences = {}
+
+    if(not (marked_unplayable or eneded_early) ):
+        if("enjoyment" in player_request_data["telemetry"]):
+            player_preferences["enjoyment"] = (player_request_data["telemetry"]["enjoyment"] - 2.5) / 2.5
+        
+        if("desiredNovelty" in player_request_data["telemetry"]):
+            player_preferences["desiredNovelty"] = (player_request_data["telemetry"]["desiredNovelty"] - 2.5) / 2.5
+        
+    return player_preferences
+
+
+def GetSimulatedPlayerTelemetry(request_data, proposed_level_data):
+    MOCK_TIME_TAKEN_PER_SLICE = [15.0 / len(proposed_level_data["levelRepresentation"])] * len(proposed_level_data["levelRepresentation"])
+    MOCK_RESPONSE = {
+        "requestId":request_data["requestId"],
+        "experimentName":request_data["experimentName"],
+        "levelRepresentation":proposed_level_data["levelRepresentation"],
+        "playthroughTelemetry":{
+            "didComplete":True,
+            "timeTaken":15.0,
+            "timeSpentInEachSlice": MOCK_TIME_TAKEN_PER_SLICE
+        }
+    }
+
+
+    simulated_player_request = {
+        "requestId":request_data["requestId"],
+        "experimentName":request_data["experimentName"],
+        "levelRepresentation":proposed_level_data["levelRepresentation"]
+    },
+
+    simulated_player_telemetry = MOCK_RESPONSE
+
+    return simulated_player_telemetry
+
+
+def IsLevelValid(request_data, proposed_level_data):
+    simulated_player_telemetry = GetSimulatedPlayerTelemetry(request_data, proposed_level_data)
+    return simulated_player_telemetry["playthroughTelemetry"]["didComplete"]
+
+
+def StoreInDatabase(request_data, response_data):
+    pass
+
+
+def GetExperimentName():
+    return level_generator.name
+
+
+
+@app.route("/")
+def landing():
+    return f"""
+    <h1>Level Evaluator and Providor</h1>
+    <h2>Providor Name: {level_generator.name}</h2>
+
+    <h3>/level</h3>
+    <h4> Request Format</h4>
+    <pre>{REQUEST_FORMAT}</pre>
+    
+    <h4> Response Format</h4>
+    <pre>{RESPONSE_FORMAT}</pre>
+    """
+
+
+@app.route("/level", methods=["GET", "POST"])
+def level():
+    if request.method == "GET":
+        data = request.args
+    else:
+        data_request = request.get_json()
+        print(data_request)
+        if not isinstance(data_request, dict):
+            data = json.loads(request.get_json())
+        else:
+            data = data_request
+    
+    data["experimentName"] = GetExperimentName()
+
+
+    # (2) Translate Player Telemetry Data to Player Preferences
+    data["playerPreferences"] = GetPlayerPreferenceFromPlayerTelemetry(player_request_data=data)
+    
+
+    # (3) Generate a level candidate
+    proposed_level_data = level_generator.GenerateLevel(request_data=data)
+
+
+    # (4) Check level is valid
+    retry_threshold = 50
+    retry_count = 0
+    level_valid = IsLevelValid(data, proposed_level_data)
+
+    while not level_valid:
+        retry_count += 1
+        
+        proposed_level_data = level_generator.GenerateLevel(request_data=data)
+        level_valid = IsLevelValid(data, proposed_level_data)
+        
+        if(retry_count >= retry_threshold):
+            break
+    
+    if(not level_valid):
+        proposed_level_data = DEFAULT_LEVEL_DATA
+
+
+    # Form Response, Store Data and Send Response
+    response = {
+        "requestId":data["requestId"],
+        "latentVector": proposed_level_data["latentVectors"],
+        "experimentName":data["experimentName"],
+        "levelRepresentation":proposed_level_data["levelRepresentation"]
+    }
+
+    StoreInDatabase(request_data=data, response_data=response)
+    
+    return jsonify(response)
+
+
+if __name__ == "__main__":
+    print("Starting Level Producer")
+    app.run()

--- a/documentation/vaerio_api.json
+++ b/documentation/vaerio_api.json
@@ -49,7 +49,7 @@
                 [ H x W array of INTs represetning block types ],
                 ...
             ],
-            "markedUplayable": BOOL,
+            "markedUnplayable": BOOL,
             "endedEarly": BOOL,
             "surveyResults":{
                 "enjoyment": INT,
@@ -87,7 +87,7 @@
         "latentVector":[ N dimenstional vector ]
     },
 
-    "levelSliceReResponse":
+    "levelSliceResponse":
     {
         "requestId":STRING,
         "experimentName":STRING,


### PR DESCRIPTION
- Add app.py as Level Evaluator and Provider endpoint
- Add LevelEvaluators module to store level evaluators
- Add LevelSliveClient for accessing level slice api
- Add RandomLevelGenerator as example evaluator
- Add EnjoymentSurfaceContentGenerator as skeleton for enjoyment surface based evaluator
- Fix typos in api documentation